### PR TITLE
fix booting from submenu (bsc #957893)

### DIFF
--- a/themes/openSUSE/src/common.inc
+++ b/themes/openSUSE/src/common.inc
@@ -207,7 +207,7 @@
       pop
 
       main.recalc
-      main.redraw
+      true main.redraw
 
       "" -1 0 return
     } if
@@ -260,7 +260,7 @@
       menu.args length {
         /menu.entry 0 def
         main.recalc
-        main.redraw
+        true main.redraw
       } {
         submenu.leave submenu.build
       } ifelse
@@ -309,7 +309,7 @@
 
   window.action actRedraw eq {
     /window.action actNothing def
-    main.redraw
+    false main.redraw
   } if
 
   window.action actRedrawPanel eq {
@@ -1076,10 +1076,7 @@
 % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 % ( text ) == > ( new_text )
 /menuitemmap {
-  % drop submenu prefix, if any
-  dup submenu.tag strstr 1 eq {
-    2 add skipnonspaces skipspaces
-  } if
+  submenu.skip_prefix
 
   translate
   config._2space {

--- a/themes/openSUSE/src/menu.inc
+++ b/themes/openSUSE/src/menu.inc
@@ -11,6 +11,8 @@
 /boot.splitchar 1 def
 /boot.splitstr 1 string dup 0 boot.splitchar put def
 
+/boot.update_options true def
+
 % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 % Create new main window.
 %
@@ -40,16 +42,19 @@
 % Redraw main window.
 % (E.g. after selecting a new language.)
 %
-% ( window ) ==> ( )
+% ( redraw_boot_options ) ==> ( )
+%
+% redraw_boot_options: true|false
+% redraw boot option line if true
 %
 /main.redraw {
 
   % boot.drawlabels
 
   main.drawmenu
-  /keepbootoptions 1 def
+  /boot.update_options exch def
   menu.entry true MenuSelect
-  /keepbootoptions .undef def
+  /boot.update_options true def
 
   panel.show
 } def
@@ -126,7 +131,7 @@
 
   free
 
-  config.nobootoptions menu.texts menu.entry get iselement
+  config.nobootoptions menu.texts menu.entry get submenu.skip_prefix iselement
   menu.args menu.entry get submenu.tag strstr 1 eq
   or
   {
@@ -302,7 +307,7 @@
 
   menu.status {
     % init boot options
-    keepbootoptions .undef eq {
+    boot.update_options {
 
       boot.input.preinit
 

--- a/themes/openSUSE/src/submenu.inc
+++ b/themes/openSUSE/src/submenu.inc
@@ -120,3 +120,15 @@
   } if
 } def
 
+
+% - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+% Skip submenu prefix, if any.
+%
+% ( string ) ==> ( string )
+%
+/submenu.skip_prefix {
+  dup submenu.tag strstr 1 eq {
+    2 add skipnonspaces skipspaces
+  } if
+} def
+


### PR DESCRIPTION
The boot option field was not properly setup immediately after entering or
leaving a submenu. This caused the kernel commandline to be not properly
assembled.

Using the cursor keys in between corrected it, so this was noticeable only
for the top submenu entry.
