### PR TITLE
Add kexec= default entry to openSUSE's gfxboot.cfg

### DIFF
--- a/themes/openSUSE/src/gfxboot.cfg
+++ b/themes/openSUSE/src/gfxboot.cfg
@@ -157,6 +157,8 @@ keymap.submenu=1
 memcheck=0
 ; apppend *.spl to initrd
 spl=1
+; If set to 1, linuxrc will load kernel and initrd from the repository and restart with them 
+kexec=
 ; move down one menu entry the first time an F-key is used
 autodown=1
 ; F-key assignments


### PR DESCRIPTION
kiwi will be able to update the value based on .kiwi files KEXEC parameter
Part of https://bugzilla.suse.com/show_bug.cgi?id=990374

With the default value being set to '', it remains the responsibility of
linuxrc to chose its own default value.

I hope I'm on the right track here - KIWI has a plugin that parses this config file and updates the lines based on configuration parameters out of the KIWI XML file (some code is needed there too to make KEXEC a known field.. also WIP)
