### PR TITLE
fix boot-label redrawing after language change (bsc #988392)

### DIFF
--- a/themes/openSUSE/src/menu.inc
+++ b/themes/openSUSE/src/menu.inc
@@ -245,6 +245,7 @@
 
   menu.visible.entries menu.max.entries lt {
     menu.visible.entries 1 menu.max.entries 1 sub {
+     pop
      x y moveto currentpoint menu.bar.width.old menu.bar.height image
      /y y menu.item.height add def
     } for


### PR DESCRIPTION
Here's why: the for-loop implicitly leaves a counter on the stack for every
iteration. It's unused but still must be removed from the stack.

Otherwise main.drawmenu() would leave unexpected values on the stack and
pollute the stack in main.redraw() which expects redraw_boot_options on the
top of the stack.
