### PR TITLE
don't crash if vbe video mode list is empty (bsc #1096971)

### DIFF
--- a/gfxboot
+++ b/gfxboot
@@ -1885,7 +1885,7 @@ sub prepare_isolinux
     symlink "i386", "$dst/boot/x86_64" if -d "$dst/boot/i386";
   }
 
-  system "genisoimage" . ($opt_verbose ? "" : " --quiet") .
+  system "mkisofs" . ($opt_verbose ? "" : " --quiet") .
     " -o $img -f -r -no-emul-boot -boot-load-size 4 -boot-info-table" .
     " -b ${loader}isolinux.bin -hide boot.catalog $dst";
 

--- a/themes/openSUSE/src/dia_video.inc
+++ b/themes/openSUSE/src/dia_video.inc
@@ -226,7 +226,8 @@
   xmenu.video.bios .xm_list [ video.modes.bios { .vm_label get } forall ] put
   xmenu.video.bios .xm_attr xmenu.video.bios .xm_list get length array put
   % line above 2nd entry
-  xmenu.video.bios .xm_attr get 1 1 put
+  % note: .xm_attr list might only have length 1
+  xmenu.video.bios .xm_attr get dup length 1 gt { 1 1 put } { pop } ifelse
   xmenu.video.bios .xm_title "Video BIOS Size" put
   xmenu.video.bios .xm_current 0 put
 


### PR DESCRIPTION
If the vbe mode list is empty only a single entry ('default') is shown. Then
don't try to store a separator line after the 1st entry...