### PR TITLE
Override mtime of files in bootlogo

### DIFF
--- a/bin/unpack_bootlogo
+++ b/bin/unpack_bootlogo
@@ -48,7 +48,11 @@ sub unpack_bootlogo
     }
   }
 
-  open P, "| cd $tmp; cpio --quiet -o >../bootlogo";
+  open P, "| cd $tmp; xargs touch -t 197001010000";
+  print P "$_\n" for grep $_, @files;
+  if($xdir) { print P "$_\n" for @ext }
+  close P;
+  open P, "| cd $tmp; cpio --quiet --reproducible --owner=+0:+0 -o >../bootlogo";
   print P "$_\n" for grep $_, @files;
   if($xdir) { print P "$_\n" for @ext }
   close P;


### PR DESCRIPTION
Override mtime of files added to bootlogo cpio
Without this patch, /etc/bootsplash/themes/KDE/cdrom/bootlogo
would differ for every build.

Together with #35 this allows for bit-identical reproducible builds of the openSUSE gfxboot package.

Note: still has some code ugly duplication - help wanted in refining it.