### PR TITLE
Replace master-boot-code by syslinux version

### DIFF
--- a/gfxboot
+++ b/gfxboot
@@ -1637,7 +1637,7 @@ sub prepare_grub
   $hdimage->type(1);
   $hdimage->label('GFXBOOT');
   $hdimage->fs('fat');
-  $hdimage->mbr('/usr/lib/boot/master-boot-code');
+  $hdimage->mbr('/usr/share/syslinux/mbr.bin');
   $hdimage->add_files(<$dst/*>);
   $hdimage->write($img);
 
@@ -1757,7 +1757,7 @@ sub prepare_lilo
   $hdimage->type(1);
   $hdimage->label('GFXBOOT');
   $hdimage->fs('fat');
-  $hdimage->mbr('/usr/lib/boot/master-boot-code');
+  $hdimage->mbr('/usr/share/syslinux/mbr.bin');
   $hdimage->add_files(<$dst/*>);
   $hdimage->write($img);
 
@@ -1991,7 +1991,7 @@ sub prepare_syslinux
   $hdimage->type(1);
   $hdimage->label('GFXBOOT');
   $hdimage->fs('fat');
-  $hdimage->mbr('/usr/lib/boot/master-boot-code');
+  $hdimage->mbr('/usr/share/syslinux/mbr.bin');
   $hdimage->add_files(<$dst/*>);
   $hdimage->write($img);
 


### PR DESCRIPTION
## Problem

`master-boot-code` package is not used (or should not) because `yast2-bootloader` now takes the master boot code from `syslinux`. Only `gfxboot` package is still using `master-boot-code`, but it uses it only for its testsuite, so it could be replaced.

* https://bugzilla.suse.com/show_bug.cgi?id=1125307
* https://trello.com/c/ARWLnK8q/832-2-gfxboot-drop-dependency-of-master-boot-code

## Solution

Adapt `gfxboot` script to not use `master-boot-code` package. The dependency of such package is also removed, so Factory would not need to include `master-boot-code` package.

* Remove `master-boot-code` dependency: https://build.opensuse.org/request/show/684226