### PR TITLE
prepare gfxboot for syslinux 6.x (jsc#SLE-2969)

### DIFF
--- a/gfxboot
+++ b/gfxboot
@@ -1797,6 +1797,9 @@ sub prepare_isolinux
   $comboot = "$opt_syslinux/usr/share/syslinux/gfxboot.com" unless -f $comboot;
   $comboot = 0 unless -f $comboot;
 
+  # syslinux 6.x
+  $opt_no_unpack = 1 if -r "$opt_syslinux/usr/share/syslinux/libcom32.c32";
+
   my $menu = fake_menu 'install';
 
   if($opt_verbose) {
@@ -1867,6 +1870,12 @@ sub prepare_isolinux
   system "cp $opt_syslinux/usr/share/syslinux/isolinux.bin $dst/$loader" and die "error: no isolinux\n";
   system "cp $comboot $dst/$loader" if $comboot;
 
+  for my $f ("ldlinux.c32", "libcom32.c32") {
+    if(-r "$opt_syslinux/usr/share/syslinux/$f" ) {
+      system "cp $opt_syslinux/usr/share/syslinux/$f $dst/$loader"
+    }
+  }
+
   for (@opt_test_addfiles) {
     system "cp -r $_ $dst/${loader}" and die "error copying file: $_\n";
   }
@@ -1911,6 +1920,9 @@ sub prepare_syslinux
   $comboot = "$opt_syslinux/usr/share/syslinux/gfxboot.c32";
   $comboot = "$opt_syslinux/usr/share/syslinux/gfxboot.com" unless -f $comboot;
   $comboot = 0 unless -f $comboot;
+
+  # syslinux 6.x
+  $opt_no_unpack = 1 if -r "$opt_syslinux/usr/share/syslinux/libcom32.c32";
 
   my $menu = fake_menu 'install';
 
@@ -2026,6 +2038,9 @@ sub prepare_pxelinux
   $comboot = "$opt_syslinux/usr/share/syslinux/gfxboot.com" unless -f $comboot;
   $comboot = 0 unless -f $comboot;
 
+  # syslinux 6.x
+  $opt_no_unpack = 1 if -r "$opt_syslinux/usr/share/syslinux/libcom32.c32";
+
   my $menu = fake_menu 'install';
 
   if($opt_verbose) {
@@ -2095,6 +2110,12 @@ sub prepare_pxelinux
 
   system "cp $opt_syslinux/usr/share/syslinux/pxelinux.0 $dst/$loader" and die "error: no pxelinux\n";
   system "cp $comboot $dst/$loader" if $comboot;
+
+  for my $f ("ldlinux.c32", "libcom32.c32") {
+    if(-r "$opt_syslinux/usr/share/syslinux/$f" ) {
+      system "cp $opt_syslinux/usr/share/syslinux/$f $dst/$loader"
+    }
+  }
 
   for (@opt_test_addfiles) {
     system "cp -r $_ $dst/${loader}" and die "error copying file: $_\n";

--- a/themes/openSUSE/src/common.inc
+++ b/themes/openSUSE/src/common.inc
@@ -647,7 +647,7 @@
 
   syslinux {
     % find out initrd sizes for kernel loading progress bar
-    /progress_extra 0 def
+    /progress_extra config.initrd.size sectorsize div 1 add def
     bc.cmd "initrd" bootopt.find dup .undef ne {
       "initrd=" length add
       dup dup skipnonspaces
@@ -1775,6 +1775,9 @@ config.livecd {
 /keymap.default        "keymap"                      "" gfxconfig.set.str
 /config.addopt.lang    "addopt.lang"              false gfxconfig.set.bool
 /config.addopt.keytable "addopt.keytable"         false gfxconfig.set.bool
+
+% default value for initrd size (in bytes)
+/config.initrd.size    "initrd.size"                  0 gfxconfig.set.int
 
 /install.install       "install"                     "" gfxconfig.set.str
 /install.http.server   "install.http.server"         "" gfxconfig.set.str

--- a/themes/openSUSE/src/gfxboot.cfg
+++ b/themes/openSUSE/src/gfxboot.cfg
@@ -180,7 +180,8 @@ key.F7=bits
 addopt.lang=1
 ; add 'keytable' option with current keymap
 addopt.keytable=1
-
+; initrd size in bytes (fallback for progress bar)
+initrd.size=0
 
 [boot]
 ; show welcome animation


### PR DESCRIPTION
## Task

Make gfxboot also work with syslinux 6.x.

## Solution

With syslinux 6.x, files on the medium can't be accessed from the gfxboot environment.

This means:

- all the boot graphics files have to be in a single cpio archive (named `bootlogo`)
- to get a proper progress bar while loading kernel & initrd, the initrd size (or at least an approximate value) has to be stored in `gfxboot.cfg`; the kernel size is known