### PR TITLE
add F8-shortcut for language selection (jsc#SLE-12810, jsc#SLE-12479)

### DIFF
--- a/themes/openSUSE/src/common.inc
+++ b/themes/openSUSE/src/common.inc
@@ -1305,7 +1305,7 @@
     moveto setcolor
   } if
 
-  dup keyF8 eq syslinux and {
+  dup keyF11 eq syslinux and {
     kroete.file .undef eq { /kroete.file "kroete.dat" findfile def } if
     kroete.file kroete.dir idle
     /kroete.dir kroete.dir 1 xor def
@@ -1341,7 +1341,7 @@
     moveto setcolor
   } if
 
-  dup keyShiftF8 eq debug 3 ge and {
+  dup keyShiftF11 eq debug 3 ge and {
     currentcolor debug 1 and { white } { black } ifelse setcolor
 
     currentpoint 300 0 moveto
@@ -1373,10 +1373,6 @@
 
   dup keyShiftF10 eq {
     /debug debug 1 add def
-  } if
-
-  dup keyShiftF11 eq {
-    400 0 moveto "ani_%04d.jpg" play_movie
   } if
 
   dup keyShiftF1 eq {
@@ -1413,47 +1409,6 @@
 
     sound.done
 
-  } if
-
-  dup keyF11 eq debug 1 ge and {
-
-    /dit {
-      dup 0xff and rand 0xff and gt { 0xff add } if
-      8 shr
-    } def
-
-    /c13.r rand 0x7f00 and def
-    /c02_13.r rand 0x7f00 and c13.r sub def
-    /c23.r rand 0x7f00 and def
-    /c01_23.r rand 0x7f00 and c23.r sub def
-    /c13.g rand 0x7f00 and def
-    /c02_13.g rand 0x7f00 and c13.g sub def
-    /c23.g rand 0x7f00 and def
-    /c01_23.g rand 0x7f00 and c23.g sub def
-    /c13.b rand 0x7f00 and def
-    /c02_13.b rand 0x7f00 and c13.b sub def
-    /c23.b rand 0x7f00 and def
-    /c01_23.b rand 0x7f00 and c23.b sub def
-
-    screen.size /h exch def /w exch def
-
-    0 1 screen.size exch pop {
-      0 1 screen.size pop {
-        over moveto
-
-        currentpoint c01_23.r mul h div exch c02_13.r mul w div add c13.r add c23.r add
-        dit 0 max 0xff min 16 shl
-        currentpoint c01_23.g mul h div exch c02_13.g mul w div add c13.g add c23.g add
-        dit 0 max 0xff min  8 shl
-        currentpoint c01_23.b mul h div exch c02_13.b mul w div add c13.b add c23.b add
-        dit 0 max 0xff min add add
-
-        setcolor putpixel
-      } for
-      pop
-    } for
-
-    pop 0
   } if
 
   dup keyF12 eq debug 6 ge and {
@@ -1775,6 +1730,7 @@ config.livecd {
 /keymap.default        "keymap"                      "" gfxconfig.set.str
 /config.addopt.lang    "addopt.lang"              false gfxconfig.set.bool
 /config.addopt.keytable "addopt.keytable"         false gfxconfig.set.bool
+/config.extralang.locales "extralang.locales"       [ ] gfxconfig.set.array_str
 
 % default value for initrd size (in bytes)
 /config.initrd.size    "initrd.size"                  0 gfxconfig.set.int

--- a/themes/openSUSE/src/dia_extralang.inc
+++ b/themes/openSUSE/src/dia_extralang.inc
@@ -1,0 +1,85 @@
+% - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+%
+% extra language switch button
+%
+% Iterate through the locales in config.extralang.locales array.
+%
+% - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+% - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+% Initialize.
+%
+% ( ) ==> ( )
+%
+/extralang.init {
+  /extralang.current 0 def
+} def
+
+
+% - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+% Get index in language menu.
+%
+% ( ) ==> ( )
+%
+/extralang.index {
+  0 1 lang.items length 1 sub {
+    lang.items over get config.extralang.locales extralang.current get eq { return } { pop } ifelse
+  } for
+  0
+} def
+
+
+% - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+% Get language name.
+%
+% ( ) ==> ( )
+%
+/extralang.name {
+  config.extralang.locales extralang.current get lang.getdefname
+} def
+
+
+% - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+% Set a new language.
+%
+% ( ) ==> ( )
+%
+/extralang.update {
+  xmenu.lang .xm_current extralang.index put
+  lang.update
+} def
+
+
+% - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+% Activate selected language.
+%
+% And also move to next language in list.
+%
+% ( ) => ( )
+%
+/panel.extralang {
+  extralang.update
+  % go to next language
+  /extralang.current extralang.current 1 add config.extralang.locales length mod def
+} def
+
+
+% - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+% Return width of panel entry.
+%
+% ( ) => ( width )
+%
+/panel.extralang.width {
+  extralang.name strsize pop
+} def
+
+
+% - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+% Redraw panel entry.
+%
+% ( panel ) => ( )
+%
+/panel.extralang.update {
+  panel.text.moveto
+  extralang.name show.rtl
+} def

--- a/themes/openSUSE/src/gfxboot.cfg
+++ b/themes/openSUSE/src/gfxboot.cfg
@@ -166,7 +166,7 @@ spl=1
 autodown=1
 ; F-key assignments
 ; value can be one of: lang, video, install, kernelopts, dud, bits, keymap,
-; profile, restore, otheropts
+; profile, restore, otheropts, extralang
 ; note1: 'bits' is only shown on x86_64, 'profile' only when a file 'profile'
 ; exists, 'restore' only when there is a boot entry 'restore'
 ; note2: F1 is always help, F9 enables speech output, F10 exits gfxboot
@@ -176,12 +176,16 @@ key.F4=install
 key.F5=kernelopts
 key.F6=dud
 key.F7=bits
+key.F8=extralang
 ; add 'lang' option with current locale
 addopt.lang=1
 ; add 'keytable' option with current keymap
 addopt.keytable=1
 ; initrd size in bytes (fallback for progress bar)
 initrd.size=0
+; languages to use for extralang option
+; use locale in long form (e.g. en_US)
+extralang.locales=zh_CN,en_US
 
 [boot]
 ; show welcome animation

--- a/themes/openSUSE/src/main.bc
+++ b/themes/openSUSE/src/main.bc
@@ -25,6 +25,7 @@
 %% include dia_restore.inc
 %% include dia_net.inc
 %% include dia_otheropts.inc
+%% include dia_extralang.inc
 %% include panel.inc
 %% include keytables.inc
 %% include locale.inc

--- a/themes/openSUSE/src/panel.inc
+++ b/themes/openSUSE/src/panel.inc
@@ -170,6 +170,7 @@
   dup "otheropts"  eq { pop [ /panel.otheropts /panel.otheropts.width /panel.otheropts.update /otheropts.init ] return } if
   dup "dud"        eq { pop [ /panel.dud /panel.dud.width /panel.dud.update /dud.init ] return } if
   dup "keymap"     eq { pop [ /panel.keymap /panel.keymap.width /panel.keymap.update /keymap.init ] return } if
+  dup "extralang"  eq { pop [ /panel.extralang /panel.extralang.width /panel.extralang.update /extralang.init ] return } if
 
   dup "bits"       eq { pop
     .undef


### PR DESCRIPTION
## Task

- dev trask https://jira.suse.com/browse/SLE-12810
- epic https://jira.suse.com/browse/SLE-12479
- scrum board https://trello.com/c/5j3DPIcq

Add `F8` key option to switch to another language directly. And use to switch between Chinese/English.

## Solution

This is controlled by these `gfxboot.cfg` config entries:
```
key.F8=extralang
extralang.locales=zh_CN,en_US
```

- `key.F8` assigns the `extralang` menu to `F8`
- `extralang.locales` is a list of languages `F8` iterates through (you can have more than two)

## Note

I'm not using the proposed 中文安装 (Chinese Installation) as label but use the language name 简体中文(Simplified Chinese) which is used in other places.

This makes it useful for other languages as well.

## Screenshots

![foo1](https://user-images.githubusercontent.com/927244/82901932-f4bd2480-9f5e-11ea-8144-e2f6dd4adff9.jpg)

![foo2](https://user-images.githubusercontent.com/927244/82901941-f7b81500-9f5e-11ea-87e8-15315d2cff89.jpg)
