### PR TITLE
add 'default' and 'https' install methods (bsc#1171018)

### DIFF
--- a/themes/openSUSE/po/af.po
+++ b/themes/openSUSE/po/af.po
@@ -503,3 +503,8 @@ msgstr ""
 msgid "Cyan on Black"
 msgstr ""
 
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "HTTPS-installasie"
+

--- a/themes/openSUSE/po/ar.po
+++ b/themes/openSUSE/po/ar.po
@@ -510,3 +510,8 @@ msgstr ""
 msgid "Cyan on Black"
 msgstr ""
 
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "تثبيت HTTPS"
+

--- a/themes/openSUSE/po/bg.po
+++ b/themes/openSUSE/po/bg.po
@@ -510,3 +510,8 @@ msgstr ""
 msgid "Cyan on Black"
 msgstr ""
 
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "Инсталиране от HTTPS"
+

--- a/themes/openSUSE/po/bootloader.pot
+++ b/themes/openSUSE/po/bootloader.pot
@@ -487,3 +487,8 @@ msgstr ""
 msgid "Cyan on Black"
 msgstr ""
 
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr ""
+

--- a/themes/openSUSE/po/ca.po
+++ b/themes/openSUSE/po/ca.po
@@ -508,3 +508,9 @@ msgstr "Blanc sobre negre"
 #. txt_cyan_on_black
 msgid "Cyan on Black"
 msgstr "Cian sobre negre"
+
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "Instal·lació per HTTPS"
+

--- a/themes/openSUSE/po/cs.po
+++ b/themes/openSUSE/po/cs.po
@@ -510,3 +510,9 @@ msgstr "Bílá na černé"
 #. txt_cyan_on_black
 msgid "Cyan on Black"
 msgstr "Zelenomodrá na černé"
+
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "Instalace pomocí protokolu HTTPS"
+

--- a/themes/openSUSE/po/da.po
+++ b/themes/openSUSE/po/da.po
@@ -511,3 +511,9 @@ msgstr "Hvid på sort"
 #. txt_cyan_on_black
 msgid "Cyan on Black"
 msgstr "Cyan på sort"
+
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "HTTPS-installation"
+

--- a/themes/openSUSE/po/de.po
+++ b/themes/openSUSE/po/de.po
@@ -511,3 +511,9 @@ msgstr "Weiß auf Schwarz"
 #. txt_cyan_on_black
 msgid "Cyan on Black"
 msgstr "Cyan auf Schwarz"
+
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "HTTPS-Installation"
+

--- a/themes/openSUSE/po/el.po
+++ b/themes/openSUSE/po/el.po
@@ -506,3 +506,8 @@ msgstr ""
 msgid "Cyan on Black"
 msgstr ""
 
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "Εγκατάσταση HTTPS"
+

--- a/themes/openSUSE/po/es.po
+++ b/themes/openSUSE/po/es.po
@@ -513,3 +513,9 @@ msgstr "Blanco sobre negro"
 #. txt_cyan_on_black
 msgid "Cyan on Black"
 msgstr "Cian sobre negro"
+
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "Instalación desde HTTPS"
+

--- a/themes/openSUSE/po/et.po
+++ b/themes/openSUSE/po/et.po
@@ -510,3 +510,8 @@ msgstr ""
 msgid "Cyan on Black"
 msgstr ""
 
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "HTTPS-paigaldus"
+

--- a/themes/openSUSE/po/fi.po
+++ b/themes/openSUSE/po/fi.po
@@ -513,3 +513,9 @@ msgstr "Valkoinen mustalla"
 #. txt_cyan_on_black
 msgid "Cyan on Black"
 msgstr "Syaani mustalla"
+
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "HTTPS-asennus"
+

--- a/themes/openSUSE/po/fr.po
+++ b/themes/openSUSE/po/fr.po
@@ -516,3 +516,8 @@ msgstr ""
 msgid "Cyan on Black"
 msgstr ""
 
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "Installation HTTPS"
+

--- a/themes/openSUSE/po/gl.po
+++ b/themes/openSUSE/po/gl.po
@@ -511,3 +511,8 @@ msgstr ""
 msgid "Cyan on Black"
 msgstr ""
 
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "Instalación por HTTPS"
+

--- a/themes/openSUSE/po/gu.po
+++ b/themes/openSUSE/po/gu.po
@@ -504,3 +504,8 @@ msgstr ""
 msgid "Cyan on Black"
 msgstr ""
 
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr " HTTPS સ્થાપન "
+

--- a/themes/openSUSE/po/hi.po
+++ b/themes/openSUSE/po/hi.po
@@ -504,3 +504,8 @@ msgstr ""
 msgid "Cyan on Black"
 msgstr ""
 
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "HTTPS अधिष्ठापन"
+

--- a/themes/openSUSE/po/hr.po
+++ b/themes/openSUSE/po/hr.po
@@ -505,3 +505,8 @@ msgstr ""
 msgid "Cyan on Black"
 msgstr ""
 
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "HTTPS instalacija"
+

--- a/themes/openSUSE/po/hu.po
+++ b/themes/openSUSE/po/hu.po
@@ -512,3 +512,8 @@ msgstr ""
 msgid "Cyan on Black"
 msgstr ""
 
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "HTTPS-telepítés"
+

--- a/themes/openSUSE/po/id.po
+++ b/themes/openSUSE/po/id.po
@@ -510,3 +510,9 @@ msgstr "Putih pada Hitam"
 #. txt_cyan_on_black
 msgid "Cyan on Black"
 msgstr "Cyan pada hitam"
+
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "Pemasangan HTTPS"
+

--- a/themes/openSUSE/po/it.po
+++ b/themes/openSUSE/po/it.po
@@ -508,3 +508,8 @@ msgstr ""
 msgid "Cyan on Black"
 msgstr ""
 
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "Installazione HTTPS"
+

--- a/themes/openSUSE/po/ja.po
+++ b/themes/openSUSE/po/ja.po
@@ -507,3 +507,9 @@ msgstr "黒い画面に白色"
 #. txt_cyan_on_black
 msgid "Cyan on Black"
 msgstr "黒い画面に青緑"
+
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "HTTPSインストール"
+

--- a/themes/openSUSE/po/ka.po
+++ b/themes/openSUSE/po/ka.po
@@ -503,3 +503,8 @@ msgstr ""
 msgid "Cyan on Black"
 msgstr ""
 
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "HTTPS-ით ჩადგმა"
+

--- a/themes/openSUSE/po/kk.po
+++ b/themes/openSUSE/po/kk.po
@@ -509,3 +509,8 @@ msgstr ""
 msgid "Cyan on Black"
 msgstr ""
 
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "HTTPS арқылы орнату"
+

--- a/themes/openSUSE/po/ko.po
+++ b/themes/openSUSE/po/ko.po
@@ -503,3 +503,8 @@ msgstr ""
 msgid "Cyan on Black"
 msgstr ""
 
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "HTTPS 설치"
+

--- a/themes/openSUSE/po/ky.po
+++ b/themes/openSUSE/po/ky.po
@@ -504,3 +504,8 @@ msgstr ""
 msgid "Cyan on Black"
 msgstr ""
 
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "HTTPS орнотулушу"
+

--- a/themes/openSUSE/po/lt.po
+++ b/themes/openSUSE/po/lt.po
@@ -508,3 +508,8 @@ msgstr ""
 msgid "Cyan on Black"
 msgstr ""
 
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "HTTPS diegimas"
+

--- a/themes/openSUSE/po/mr.po
+++ b/themes/openSUSE/po/mr.po
@@ -505,3 +505,8 @@ msgstr ""
 msgid "Cyan on Black"
 msgstr ""
 
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "HTTPS स्थापना"
+

--- a/themes/openSUSE/po/nb.po
+++ b/themes/openSUSE/po/nb.po
@@ -510,3 +510,8 @@ msgstr ""
 msgid "Cyan on Black"
 msgstr ""
 
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "HTTPS-installasjon"
+

--- a/themes/openSUSE/po/nl.po
+++ b/themes/openSUSE/po/nl.po
@@ -514,3 +514,8 @@ msgstr ""
 msgid "Cyan on Black"
 msgstr ""
 
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "HTTPS-installatie"
+

--- a/themes/openSUSE/po/pa.po
+++ b/themes/openSUSE/po/pa.po
@@ -515,3 +515,8 @@ msgstr ""
 msgid "Cyan on Black"
 msgstr ""
 
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "HTTPS ਇੰਸਟਾਲੇਸ਼ਨ"
+

--- a/themes/openSUSE/po/pl.po
+++ b/themes/openSUSE/po/pl.po
@@ -508,3 +508,8 @@ msgstr ""
 msgid "Cyan on Black"
 msgstr ""
 
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "Instalacja przez HTTPS"
+

--- a/themes/openSUSE/po/pt.po
+++ b/themes/openSUSE/po/pt.po
@@ -513,3 +513,8 @@ msgstr ""
 msgid "Cyan on Black"
 msgstr ""
 
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "Instalação por HTTPS"
+

--- a/themes/openSUSE/po/pt_BR.po
+++ b/themes/openSUSE/po/pt_BR.po
@@ -508,3 +508,9 @@ msgstr "Branco no preto"
 #. txt_cyan_on_black
 msgid "Cyan on Black"
 msgstr "Ciano no preto"
+
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "Instalação por HTTPS"
+

--- a/themes/openSUSE/po/ro.po
+++ b/themes/openSUSE/po/ro.po
@@ -508,3 +508,8 @@ msgstr ""
 msgid "Cyan on Black"
 msgstr ""
 
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "Instalare prin HTTPS"
+

--- a/themes/openSUSE/po/ru.po
+++ b/themes/openSUSE/po/ru.po
@@ -510,3 +510,8 @@ msgstr ""
 msgid "Cyan on Black"
 msgstr ""
 
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "Настройка HTTPS"
+

--- a/themes/openSUSE/po/sk.po
+++ b/themes/openSUSE/po/sk.po
@@ -514,3 +514,9 @@ msgstr "Biela na čiernej"
 #. txt_cyan_on_black
 msgid "Cyan on Black"
 msgstr "Azúrová na čiernej"
+
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "HTTPS Inštalácia"
+

--- a/themes/openSUSE/po/sl.po
+++ b/themes/openSUSE/po/sl.po
@@ -513,3 +513,8 @@ msgstr ""
 msgid "Cyan on Black"
 msgstr ""
 
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "Namestitev preko HTTPS"
+

--- a/themes/openSUSE/po/sr.po
+++ b/themes/openSUSE/po/sr.po
@@ -503,3 +503,8 @@ msgstr ""
 msgid "Cyan on Black"
 msgstr ""
 
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "HTTPS инсталација"
+

--- a/themes/openSUSE/po/sv.po
+++ b/themes/openSUSE/po/sv.po
@@ -507,3 +507,9 @@ msgstr "Vit på svart"
 #. txt_cyan_on_black
 msgid "Cyan on Black"
 msgstr "Cyan på svart"
+
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "HTTPS-installation"
+

--- a/themes/openSUSE/po/ta.po
+++ b/themes/openSUSE/po/ta.po
@@ -504,3 +504,8 @@ msgstr ""
 msgid "Cyan on Black"
 msgstr ""
 
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "HTTPS நிறுவுதல்"
+

--- a/themes/openSUSE/po/tg.po
+++ b/themes/openSUSE/po/tg.po
@@ -490,3 +490,8 @@ msgstr ""
 msgid "Cyan on Black"
 msgstr ""
 
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "Коргузории HTTPS"
+

--- a/themes/openSUSE/po/th.po
+++ b/themes/openSUSE/po/th.po
@@ -509,3 +509,9 @@ msgstr "ขาวบนดำ"
 #. txt_cyan_on_black
 msgid "Cyan on Black"
 msgstr "สีน้ำเงินเขียวบนดำ"
+
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "ติดตั้งผ่านทาง HTTPS"
+

--- a/themes/openSUSE/po/tr.po
+++ b/themes/openSUSE/po/tr.po
@@ -504,3 +504,8 @@ msgstr ""
 msgid "Cyan on Black"
 msgstr ""
 
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "HTTPS kurulumu"
+

--- a/themes/openSUSE/po/uk.po
+++ b/themes/openSUSE/po/uk.po
@@ -513,3 +513,8 @@ msgstr ""
 msgid "Cyan on Black"
 msgstr ""
 
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "Встановлення через HTTPS"
+

--- a/themes/openSUSE/po/wa.po
+++ b/themes/openSUSE/po/wa.po
@@ -506,3 +506,8 @@ msgstr ""
 msgid "Cyan on Black"
 msgstr ""
 
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "Astalaedje HTTPS"
+

--- a/themes/openSUSE/po/xh.po
+++ b/themes/openSUSE/po/xh.po
@@ -501,3 +501,8 @@ msgstr ""
 msgid "Cyan on Black"
 msgstr ""
 
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "Ukuhlohlwa kwe-HTTPS"
+

--- a/themes/openSUSE/po/zh_CN.po
+++ b/themes/openSUSE/po/zh_CN.po
@@ -508,3 +508,9 @@ msgstr "黑底白字"
 #. txt_cyan_on_black
 msgid "Cyan on Black"
 msgstr "黑底青字"
+
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "HTTPS 安装"
+

--- a/themes/openSUSE/po/zh_TW.po
+++ b/themes/openSUSE/po/zh_TW.po
@@ -505,3 +505,8 @@ msgstr ""
 msgid "Cyan on Black"
 msgstr ""
 
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "HTTPS 安裝"
+

--- a/themes/openSUSE/po/zu.po
+++ b/themes/openSUSE/po/zu.po
@@ -501,3 +501,8 @@ msgstr ""
 msgid "Cyan on Black"
 msgstr ""
 
+#. dialog title for https installation
+#. txt_https_title
+msgid "HTTPS Installation"
+msgstr "Ukufakwa Kwe-HTTPS"
+

--- a/themes/openSUSE/src/dia_install.inc
+++ b/themes/openSUSE/src/dia_install.inc
@@ -12,22 +12,19 @@
 /proxy.option 255 string def
 
 % install types
-/.inst_cdrom	0 def
-/.inst_hd	1 def
-/.inst_slp	2 def
-/.inst_ftp	3 def
-/.inst_http	4 def
-/.inst_nfs	5 def
-/.inst_smb	6 def
-/.inst_net_setup 7 def
-/.inst_net_proxy 8 def
+/.inst_default	  0 def
+/.inst_cdrom	  1 def
+/.inst_hd	  2 def
+/.inst_slp	  3 def
+/.inst_ftp	  4 def
+/.inst_http	  5 def
+/.inst_https	  6 def
+/.inst_nfs	  7 def
+/.inst_smb	  8 def
+/.inst_net_setup  9 def
+/.inst_net_proxy 10 def
 
-/install.default .inst_cdrom def
-
-% isohybrid image booted as disk
-sectorsize 0x200 eq bootdrive 0x80 eq or {
-  /install.default .inst_hd def
-} if
+/install.default .inst_default def
 
 % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 % Build install mode list.
@@ -52,11 +49,13 @@ sectorsize 0x200 eq bootdrive 0x80 eq or {
 
   % see install types (.inst_*)
   xmenu .xm_list [
+    /txt_kernel_default
     is_dvd { "DVD" } { "CD-ROM" } ifelse
     /txt_harddisk
     "SLP"
     "FTP"
     "HTTP"
+    "HTTPS"
     "NFS"
     "SMB / CIFS"
     /txt_network_config
@@ -70,10 +69,10 @@ sectorsize 0x200 eq bootdrive 0x80 eq or {
   xmenu .xm_submenus xmenu .xm_list get length array put
   xmenu .xm_attr xmenu .xm_list get length array put
 
-  % separation line above 3rd (slp) and 8th (net setup) entry (0-based count)
-  xmenu .xm_attr get dup .inst_slp 1 put .inst_net_setup 1 put
+  % separation line above cdrom entry and net setup entry
+  xmenu .xm_attr get dup .inst_cdrom 1 put .inst_net_setup 1 put
 
-  % attach network config menu to 8th (net setup) entry (0-based count)
+  % attach network config menu to net setup entry
   xmenu .xm_submenus get .inst_net_setup xmenu.net put
 
   xmenu .xm_title /txt_install_source put
@@ -97,7 +96,7 @@ sectorsize 0x200 eq bootdrive 0x80 eq or {
     xmenu .xm_current over .xm_last get put
     panel.net
   } {
-    xmenu .xm_current get dup .inst_cdrom eq exch .inst_slp eq or {
+    xmenu .xm_current get dup .inst_default eq exch dup .inst_cdrom eq exch .inst_slp eq or or {
       install.set.install.option
       /window.action actRedrawPanel def
     } {
@@ -177,6 +176,16 @@ sectorsize 0x200 eq bootdrive 0x80 eq or {
 
   dup .inst_http eq {
     dia .title txt_http_title put
+
+    % Must all be of same size!
+    dia .ed.list 2 array put
+    dia .ed.buffer.list input.edit.http put
+    dia .ed.text.list [ txt_server txt_directory ] put
+
+  } if
+
+  dup .inst_https eq {
+    dia .title txt_https_title put
 
     % Must all be of same size!
     dia .ed.list 2 array put
@@ -282,7 +291,7 @@ sectorsize 0x200 eq bootdrive 0x80 eq or {
   xmenu .xm_current get
 
   dup .inst_net_proxy ne {
-    % default: .inst_cdrom
+    % default: .inst_default
     install.option "" strcpy pop
   } if
 
@@ -312,6 +321,13 @@ sectorsize 0x200 eq bootdrive 0x80 eq or {
     dup 1 get dup 0 get '/' eq { 1 add } if
     exch 0 get
     "install=http://%s/%s" install.option sprintf
+  } if
+
+  dup .inst_https eq {
+    input.edit.http
+    dup 1 get dup 0 get '/' eq { 1 add } if
+    exch 0 get
+    "install=https://%s/%s" install.option sprintf
   } if
 
   dup .inst_nfs eq {
@@ -352,6 +368,10 @@ sectorsize 0x200 eq bootdrive 0x80 eq or {
     "install=hd://%s/%s" install.option sprintf
   } if
 
+  dup .inst_cdrom eq {
+    install.option "install=cd:/" strcpy pop
+  } if
+
   dup .inst_net_proxy eq {
     input.edit.proxy
       dup 0 get "" ne {
@@ -384,12 +404,21 @@ sectorsize 0x200 eq bootdrive 0x80 eq or {
 /install.read.config {
   install.install
   dup "cdrom" eq { /install.default .inst_cdrom def } if
+  dup "hd"    eq { /install.default .inst_hd    def } if
+  dup "disk"  eq {
+    % isohybrid image may be cdrom or hard disk
+    sectorsize 0x200 eq bootdrive 0x80 eq or {
+      /install.default .inst_hd def
+    } {
+      /install.default .inst_cdrom def
+    } ifelse
+  } if
   dup "slp"   eq { /install.default .inst_slp   def } if
   dup "ftp"   eq { /install.default .inst_ftp   def } if
   dup "http"  eq { /install.default .inst_http  def } if
+  dup "https" eq { /install.default .inst_https def } if
   dup "nfs"   eq { /install.default .inst_nfs   def } if
   dup "smb"   eq { /install.default .inst_smb   def } if
-  dup "hd"    eq { /install.default .inst_hd    def } if
   pop
 
   input.edit.http 0 get install.http.server strcpy pop
@@ -445,5 +474,4 @@ sectorsize 0x200 eq bootdrive 0x80 eq or {
 } def
 
 /url_esc_buf 256 string def
-
 

--- a/themes/openSUSE/src/gfxboot.cfg
+++ b/themes/openSUSE/src/gfxboot.cfg
@@ -117,7 +117,10 @@ mediacheck=mediachk
 nobootoptions=harddisk,memtest
 ; main menu items that are not passed an 'install' parameter
 noinstallopt=harddisk,firmware,memtest
-; default install method (one of: cdrom, slp, ftp, http, nfs, smb, hd; default: cdrom)
+; install method (one of: <empty> (== default), cdrom, hd, disk, slp, ftp, http,
+;   https, nfs, smb)
+;   - disk: auto-detect between cdrom or hd depending on how the image was booted
+;   - https & http share the same server/path components
 install=
 ; default repo location
 install.http.server=


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1171018
- https://trello.com/c/Ze6ppnAz

On our network installation media, the URL for the network repository is stored in two places

  1. in the initrd as [`defaultrepo`](https://en.opensuse.org/SDB:Linuxrc#p_defaultinstall) option to linuxrc
  1. in gfxboot.cfg as `install.http` option - and the install method is set to `http`

The aim here is to get rid of the 2nd way. It is superfluous (it used to be the only way in the past) and not available for EFI based booting anyway.

This means that both DVD and network ISO must show the same default installation method. And that would be `CD-ROM` in the existing implementation - which doesn't make sense for a network ISO.

That's why a new `default` install method has been added.

When `default` is selected, no `install` boot option is added by gfxboot.

## Bonus

While we're working at it, let's add the missing `https` method.

## Screenshots

![bar](https://user-images.githubusercontent.com/927244/84673596-358ad680-af2a-11ea-9d36-928e8a0f4e77.jpg)

Before it used to look like this:

![bar2](https://user-images.githubusercontent.com/927244/84673872-87cbf780-af2a-11ea-8a08-baf1c60da681.jpg)