### PR TITLE
reproducible builds: build example themes reproducibly

### DIFF
--- a/gfxboot
+++ b/gfxboot
@@ -2616,7 +2616,7 @@ sub pack_archive
     }
 
     if(@pack_list) {
-      open $f, "| ( cd $dir ; cpio --quiet -o ) >$file/$archive";
+      open $f, "| ( cd $dir ; cpio --quiet --reproducible --owner=+0:+0 -o ) >$file/$archive";
       print $f join("\n", @pack_list);
       close $f;
     }
@@ -2625,7 +2625,7 @@ sub pack_archive
   else {
     $file = $gfxboot_tmp->file;
 
-    $i = system "cd $dir ; find . | cpio --quiet -o >$file 2>/dev/null";
+    $i = system "cd $dir ; find . | cpio --quiet --reproducible --owner=+0:+0 -o >$file 2>/dev/null";
     die "$file: failed to create archive\n" if $i;
   }
 

--- a/gfxboot
+++ b/gfxboot
@@ -2625,7 +2625,7 @@ sub pack_archive
   else {
     $file = $gfxboot_tmp->file;
 
-    $i = system "cd $dir ; find . | cpio --quiet --reproducible --owner=+0:+0 -o >$file 2>/dev/null";
+    $i = system "cd $dir ; find . -mindepth 1 | cpio --quiet --reproducible --owner=+0:+0 -o >$file 2>/dev/null";
     die "$file: failed to create archive\n" if $i;
   }
 

--- a/themes/example_01/Makefile
+++ b/themes/example_01/Makefile
@@ -12,7 +12,7 @@ bootlogo: example_*.bc
 	@rm -rf $@.dir
 	@mkdir $@.dir
 	$(GFXBOOT_COMPILE) $(BFLAGS) -l $@.log -c $< $@.dir/init
-	touch --reference Makefile $@.dir/*
+	touch --reference example_01.bc $@.dir/*
 	$(GFXBOOT) --archive $@.dir --pack-archive $@
 
 clean:

--- a/themes/example_01/Makefile
+++ b/themes/example_01/Makefile
@@ -12,6 +12,7 @@ bootlogo: example_*.bc
 	@rm -rf $@.dir
 	@mkdir $@.dir
 	$(GFXBOOT_COMPILE) $(BFLAGS) -l $@.log -c $< $@.dir/init
+	touch --reference Makefile $@.dir/*
 	$(GFXBOOT) --archive $@.dir --pack-archive $@
 
 clean:

--- a/themes/example_02/Makefile
+++ b/themes/example_02/Makefile
@@ -13,6 +13,7 @@ bootlogo: example_*.bc font
 	@mkdir $@.dir
 	$(GFXBOOT_COMPILE) $(BFLAGS) -l $@.log -c $< $@.dir/init
 	@cp font.fnt $@.dir
+	touch --reference Makefile $@.dir/*
 	$(GFXBOOT) --archive $@.dir --pack-archive $@
 
 font:

--- a/themes/example_02/Makefile
+++ b/themes/example_02/Makefile
@@ -13,7 +13,7 @@ bootlogo: example_*.bc font
 	@mkdir $@.dir
 	$(GFXBOOT_COMPILE) $(BFLAGS) -l $@.log -c $< $@.dir/init
 	@cp font.fnt $@.dir
-	touch --reference Makefile $@.dir/*
+	touch --reference example_02.bc $@.dir/*
 	$(GFXBOOT) --archive $@.dir --pack-archive $@
 
 font:

--- a/themes/example_03/Makefile
+++ b/themes/example_03/Makefile
@@ -13,6 +13,7 @@ bootlogo: example_*.bc font
 	@mkdir $@.dir
 	$(GFXBOOT_COMPILE) $(BFLAGS) -l $@.log -c $< $@.dir/init
 	@cp clouds.jpg font.fnt $@.dir
+	touch --reference Makefile $@.dir/*
 	$(GFXBOOT) --archive $@.dir --pack-archive $@
 
 font:

--- a/themes/example_03/Makefile
+++ b/themes/example_03/Makefile
@@ -13,7 +13,7 @@ bootlogo: example_*.bc font
 	@mkdir $@.dir
 	$(GFXBOOT_COMPILE) $(BFLAGS) -l $@.log -c $< $@.dir/init
 	@cp clouds.jpg font.fnt $@.dir
-	touch --reference Makefile $@.dir/*
+	touch --reference example_03.bc $@.dir/*
 	$(GFXBOOT) --archive $@.dir --pack-archive $@
 
 font:

--- a/themes/example_04/Makefile
+++ b/themes/example_04/Makefile
@@ -13,6 +13,7 @@ bootlogo: example_*.bc font
 	@mkdir $@.dir
 	$(GFXBOOT_COMPILE) $(BFLAGS) -l $@.log -c $< $@.dir/init
 	@cp clouds.jpg font.fnt $@.dir
+	touch --reference Makefile $@.dir/*
 	$(GFXBOOT) --archive $@.dir --pack-archive $@
 
 font:

--- a/themes/example_04/Makefile
+++ b/themes/example_04/Makefile
@@ -13,7 +13,7 @@ bootlogo: example_*.bc font
 	@mkdir $@.dir
 	$(GFXBOOT_COMPILE) $(BFLAGS) -l $@.log -c $< $@.dir/init
 	@cp clouds.jpg font.fnt $@.dir
-	touch --reference Makefile $@.dir/*
+	touch --reference example_04.bc $@.dir/*
 	$(GFXBOOT) --archive $@.dir --pack-archive $@
 
 font:

--- a/themes/example_05/Makefile
+++ b/themes/example_05/Makefile
@@ -13,7 +13,7 @@ bootlogo: example_*.bc font
 	@mkdir $@.dir
 	$(GFXBOOT_COMPILE) $(BFLAGS) -l $@.log -c $< $@.dir/init
 	@cp clouds.jpg font.fnt $@.dir
-	touch --reference Makefile $@.dir/*
+	touch --reference example_05.bc $@.dir/*
 	$(GFXBOOT) --archive $@.dir --pack-archive $@
 
 font:

--- a/themes/example_05/Makefile
+++ b/themes/example_05/Makefile
@@ -13,6 +13,7 @@ bootlogo: example_*.bc font
 	@mkdir $@.dir
 	$(GFXBOOT_COMPILE) $(BFLAGS) -l $@.log -c $< $@.dir/init
 	@cp clouds.jpg font.fnt $@.dir
+	touch --reference Makefile $@.dir/*
 	$(GFXBOOT) --archive $@.dir --pack-archive $@
 
 font:

--- a/themes/example_06/Makefile
+++ b/themes/example_06/Makefile
@@ -16,7 +16,7 @@ bootlogo: example_*.bc font
 	@mkdir $@.dir
 	$(GFXBOOT_COMPILE) $(BFLAGS) -l $@.log -c $< $@.dir/init
 	@cp $(FILES) $@.dir
-	touch --reference Makefile $@.dir/*
+	touch --reference example_06.bc $@.dir/*
 	$(GFXBOOT) --archive $@.dir --pack-archive $@
 	@ln -snf bootlogo message
 

--- a/themes/example_06/Makefile
+++ b/themes/example_06/Makefile
@@ -16,6 +16,7 @@ bootlogo: example_*.bc font
 	@mkdir $@.dir
 	$(GFXBOOT_COMPILE) $(BFLAGS) -l $@.log -c $< $@.dir/init
 	@cp $(FILES) $@.dir
+	touch --reference Makefile $@.dir/*
 	$(GFXBOOT) --archive $@.dir --pack-archive $@
 	@ln -snf bootlogo message
 

--- a/themes/example_07/Makefile
+++ b/themes/example_07/Makefile
@@ -16,7 +16,7 @@ bootlogo: example_*.bc font
 	@mkdir $@.dir
 	$(GFXBOOT_COMPILE) $(BFLAGS) -l $@.log -c $< $@.dir/init
 	@cp $(FILES) $@.dir
-	touch --reference Makefile $@.dir/*
+	touch --reference example_07.bc $@.dir/*
 	$(GFXBOOT) --archive $@.dir --pack-archive $@
 	@ln -snf bootlogo message
 

--- a/themes/example_07/Makefile
+++ b/themes/example_07/Makefile
@@ -16,6 +16,7 @@ bootlogo: example_*.bc font
 	@mkdir $@.dir
 	$(GFXBOOT_COMPILE) $(BFLAGS) -l $@.log -c $< $@.dir/init
 	@cp $(FILES) $@.dir
+	touch --reference Makefile $@.dir/*
 	$(GFXBOOT) --archive $@.dir --pack-archive $@
 	@ln -snf bootlogo message
 


### PR DESCRIPTION
This makes changes to "gfxboot" and themes/example*/Makefile very similar to the changes applied in:

  https://github.com/openSUSE/gfxboot/pull/35

Bug reported in Debian:

  https://bugs.debian.org/978946

Related reproducible builds Issues tracked in Debian:

  https://tests.reproducible-builds.org/debian/issues/unstable/users_and_groups_in_cpio_archive_issue.html
  https://tests.reproducible-builds.org/debian/issues/unstable/timestamps_in_cpio_archive_issue.html