### PR TITLE
Do not generate .note.gnu.property section.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ vocabulary.h: mk_vocabulary
 	./mk_vocabulary -c >$@
 
 jpeg.o: jpeg.S
-	as --32 -ahlsn=jpeg.lst -o $@ $<
+	as --32 -mx86-used-note=no -ahlsn=jpeg.lst -o $@ $<
 
 install: all
 	install -d -m 755 $(DESTDIR)/usr/sbin


### PR DESCRIPTION
Starting from binutils 2.36, by default, the assembler uses
-mx86-used-note=yes which leads to a huge binary as default
linker scripts puts the section at the following offset:

```
.note.gnu.property
                0x0000000008048000       0x28
 .note.gnu.property
                0x0000000008048000       0x28 main.o
```

That's 135MB and then ./bin2c bincode >bincode.h generates
huge header file and GCC then consumes a lot of memory.