### PR TITLE
work around broken Video BIOS: in case VBE video mode list is empty, try VESA pre-defined mode numbers (bsc#1199896)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ A more minimalistic [example](themes/example_07/example_07.bc) included in the g
 
 To build, simply run `make`. Install with `make install`.
 
+To build a reference for the stack-based bincode (used in `themes/openSUSE/src/*.inc`), run
+
+```console
+$ make doc
+$ xdg-open doc/gfxboot.html || less doc/gfxboot.txt
+```
+
 Basically every new commit into the master branch of the repository will be auto-submitted
 to all current SUSE products. No further action is needed except accepting the pull request.
 

--- a/themes/openSUSE/src/common.inc
+++ b/themes/openSUSE/src/common.inc
@@ -1564,15 +1564,45 @@
 %
 % Prefer 32 bit mode with fallback to 16 bit.
 %
+% If no mode was found in supported mode list, try VESA pre-defined mode
+% number (bsc#1199896).
+%
 % ( width height -- true|false )
 %
 /set_videomode {
-  over over
-  32 findmode setmode {
+  over over 32 findmode setmode {
     pop pop true
   } {
-    16 findmode setmode
+    over over 16 findmode setmode {
+      pop pop true
+    } {
+      legacy_videomode setmode
+    } ifelse
   } ifelse
+} def
+
+
+% - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+% Look up old VESA pre-defined mode number (64k color modes).
+%
+% ( width height -- mode number | .undef )
+%
+/legacy_videomode {
+  over over 768 eq exch 1024 eq and {
+    0x117
+  } {
+    over over 600 eq exch 800 eq and {
+      0x114
+    } {
+      over over 480 eq exch 640 eq and {
+        0x111
+      } {
+        .undef
+      } ifelse
+    } ifelse
+  } ifelse
+
+  rot pop exch pop
 } def
 
 


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1199896
- https://trello.com/c/HvGOgxf2

When booting the installation media in legacy mode, no graphic UI comes up but a message 'graphics initialization failed' is shown.

## Analysis

This looks like a Legacy Video BIOS bug in this specific system. The video mode list int 10h VBE call 0x4f00 is returning is empty (16 bit little endian values, should be in the red marked area - 0xffff is the list end marker):

![n4_1](https://user-images.githubusercontent.com/927244/171407573-1f9bada8-7375-412f-a2fa-fa7f73415cf3.png)

Here's what it normally looks like:

![ok](https://user-images.githubusercontent.com/927244/171410915-0e7d8fbd-0631-42a4-b9f2-4e5c4e79f93a.png)

## Solution

As a last ditch attempt, try the old VESA pre-defined mode numbers.

See [VESA BIOS Extension Specification, version 3.0](http://www.petesqbsite.com/sections/tutorials/tuts/vbe3.pdf), page 19.