### PR TITLE
limit the 'autodown' feature to first key press

### DIFF
--- a/themes/openSUSE/src/gfxboot.cfg
+++ b/themes/openSUSE/src/gfxboot.cfg
@@ -165,7 +165,7 @@ keymap.submenu=1
 memcheck=0
 ; apppend *.spl to initrd
 spl=1
-; move down one menu entry the first time an F-key is used
+; move down one menu entry if the first key is an F-key
 autodown=1
 ; F-key assignments
 ; value can be one of: lang, video, install, kernelopts, dud, bits, keymap,

--- a/themes/openSUSE/src/menu.inc
+++ b/themes/openSUSE/src/menu.inc
@@ -558,8 +558,12 @@
 
   dup 0 ne {
     "opt" help.setcontext
-  } if
+  } {
+    % set if at least one key has been processed
+    % see panel::panel.extra
 
+    /panel.extra.fkey 1 def
+  } ifelse
 } def
 
 

--- a/themes/openSUSE/src/panel.inc
+++ b/themes/openSUSE/src/panel.inc
@@ -128,8 +128,9 @@
 % ( key ) => ( key )
 %
 /panel.extra {
-  % move down one menu entry; but only once
-  % see keyDown in menu::main.input
+  % move down one menu entry if the first entry is currently selected - but
+  % only once
+  % see also menu::main.input
 
   % only for install CDs
   config.autodown not { return } if


### PR DESCRIPTION
## Problem

If `config.autodown` is set, the main menu would automatically move one menu entry down the first time an F-key is used.

This was originally intended to keep people from selecting the 'local boot' option (usually first entry) accidentally.

But this has unwanted side effects if you go via 'more...' to a second level menu: it would do the same there.

## Example

On SUSE install media, go to the `Rescue System` entry. Then use `F2` to change the language.

## Solution

To avoid this, limit this feature to the first key press.